### PR TITLE
Add Nordpool cheap slots integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Nordpool Cheap Slots Home Assistant Integration
+
+This custom component fetches electricity prices from Nordpool and exposes two
+switches that turn on during the cheapest periods of the day.
+
+* `switch.cheap_1h_slot` &ndash; turns on during the cheapest single hour.
+* `switch.cheap_3h_slot` &ndash; turns on during the cheapest three consecutive hours.
+
+## Installation
+
+Copy the `custom_components/nordpool_cheap` directory to your Home Assistant
+`config/custom_components` folder.
+
+Add the following to your `configuration.yaml` and restart Home Assistant:
+
+```yaml
+nordpool_cheap:
+  region: "Europe/Stockholm"
+```
+
+Use these switches to trigger automations when electricity prices are low.

--- a/custom_components/nordpool_cheap/__init__.py
+++ b/custom_components/nordpool_cheap/__init__.py
@@ -1,0 +1,45 @@
+"""Nordpool cheap slots integration."""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_time_interval
+
+from .switch import CheapSlotSwitch
+from .const import DOMAIN
+from .price_fetcher import PriceFetcher
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the integration via configuration.yaml."""
+    conf = config.get(DOMAIN)
+    if conf is None:
+        return True
+    region = conf.get("region", "Europe/Stockholm")
+    hours = conf.get("hours", 24)
+
+    fetcher = PriceFetcher(hass, region, hours)
+    hass.data[DOMAIN] = {
+        "fetcher": fetcher,
+        "switches": [],
+    }
+
+    one_hour = CheapSlotSwitch(fetcher, 1, "Cheap 1h Slot")
+    three_hour = CheapSlotSwitch(fetcher, 3, "Cheap 3h Slot")
+    hass.data[DOMAIN]["switches"].extend([one_hour, three_hour])
+
+    async def refresh(_now):
+        await fetcher.async_update()
+        for entity in hass.data[DOMAIN]["switches"]:
+            entity.async_schedule_update_ha_state(True)
+
+    await fetcher.async_update()
+    async_track_time_interval(hass, refresh, timedelta(hours=1))
+
+    for entity in hass.data[DOMAIN]["switches"]:
+        entity.hass = hass
+        hass.async_create_task(entity.async_update_ha_state(True))
+
+    return True

--- a/custom_components/nordpool_cheap/const.py
+++ b/custom_components/nordpool_cheap/const.py
@@ -1,0 +1,1 @@
+DOMAIN = "nordpool_cheap"

--- a/custom_components/nordpool_cheap/manifest.json
+++ b/custom_components/nordpool_cheap/manifest.json
@@ -1,0 +1,9 @@
+{
+    "domain": "nordpool_cheap",
+    "name": "Nordpool Cheap Slots",
+    "version": "0.1",
+    "documentation": "https://github.com/example/nordpool_cheap",
+    "dependencies": [],
+    "codeowners": [],
+    "requirements": ["nordpool"]
+}

--- a/custom_components/nordpool_cheap/price_fetcher.py
+++ b/custom_components/nordpool_cheap/price_fetcher.py
@@ -1,0 +1,47 @@
+"""Fetch prices from Nordpool and compute cheap slots."""
+
+import datetime
+from datetime import timedelta
+from typing import List
+
+from homeassistant.util import dt as dt_util
+from homeassistant.core import HomeAssistant
+from nordpool import elspot
+
+class PriceFetcher:
+    """Fetch Nordpool prices and compute cheapest slots."""
+
+    def __init__(self, hass: HomeAssistant, region: str, hours: int = 24) -> None:
+        self.hass = hass
+        self.region = region
+        self.hours = hours
+        self.prices: List[float] = []
+        self.cheapest_1h_start: datetime.datetime | None = None
+        self.cheapest_3h_start: datetime.datetime | None = None
+
+    def _get_prices(self) -> List[float]:
+        prices_spot = elspot.Prices()
+        data = prices_spot.get_prices(self.region)
+        today = data["today"]
+        return [h["value"] for h in today][: self.hours]
+
+    def _calculate_slots(self) -> None:
+        if not self.prices:
+            self.cheapest_1h_start = None
+            self.cheapest_3h_start = None
+            return
+        start_day = dt_util.start_of_local_day()
+        idx_min = self.prices.index(min(self.prices))
+        self.cheapest_1h_start = start_day + timedelta(hours=idx_min)
+        best_avg = None
+        best_idx = 0
+        for idx in range(len(self.prices) - 2):
+            avg = sum(self.prices[idx : idx + 3]) / 3
+            if best_avg is None or avg < best_avg:
+                best_avg = avg
+                best_idx = idx
+        self.cheapest_3h_start = start_day + timedelta(hours=best_idx)
+
+    async def async_update(self) -> None:
+        self.prices = await self.hass.async_add_executor_job(self._get_prices)
+        self._calculate_slots()

--- a/custom_components/nordpool_cheap/switch.py
+++ b/custom_components/nordpool_cheap/switch.py
@@ -1,0 +1,44 @@
+"""Switches representing cheap slots."""
+
+from datetime import timedelta
+import datetime
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+class CheapSlotSwitch(SwitchEntity):
+    """Switch that is on during the cheapest slot."""
+
+    def __init__(self, fetcher, hours: int, name: str) -> None:
+        self._fetcher = fetcher
+        self._hours = hours
+        self._name = name
+        self._start: datetime.datetime | None = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def is_on(self) -> bool:
+        if self._start is None:
+            return False
+        end = self._start + timedelta(hours=self._hours)
+        now = dt_util.now()
+        return self._start <= now < end
+
+    async def async_update(self) -> None:
+        await self._fetcher.async_update()
+        if self._hours == 1:
+            self._start = self._fetcher.cheapest_1h_start
+        else:
+            self._start = self._fetcher.cheapest_3h_start
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the switches."""
+    data = hass.data.get(DOMAIN)
+    if not data:
+        return
+    async_add_entities(data["switches"], True)


### PR DESCRIPTION
## Summary
- add a custom component `nordpool_cheap` for Home Assistant
- compute cheapest 1h and 3h slots from Nordpool prices
- expose switches that turn on during those slots
- document setup instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686833ab70208332b78376b3be981aac